### PR TITLE
QSP-1175: Min price lower cap implemented

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ You can request an audit as follows:
 
 where:
 * `uri` is URI for the smart contract you wish to audit. This URI must ​not be a link to Etherscan, Etherchain, etc. It must be a web address which returns only​ plain Solidity source code, like this ​[URI example​](https://raw.githubusercontent.com/OpenZeppelin/openzeppelin-solidity/1d2d18f9dab55b58802c3b1e70257183bb558aa2/contracts/math/SafeMath.sol). Do ​not​ enter a [​URL to a Github repo like this example​](https://github.com/OpenZeppelin/openzeppelin-solidity/blob/master/contracts/math/SafeMath.sol). We need the URI to the raw code, directly. Note that our protocol currently supports Solidity up to version 0.4.24, and that the version must be prefixed with the caret character (^) if it’s lower than 0.4.24.
-* `price` is the audit price. The audit price should be no higher than the amount you granted the Quantstamp protocol permission to withdraw in Step 1. As previously, you may find it handy to use the conversion function `web3.toWei(n, "ether")` (where `n` is the amount of QSP tokens) to obtain the correct QSP amount. Note that the price determines how quickly an audit request will be picked by some audit node.
+* `price` is the audit price. The audit price should be no higher than the amount you granted the Quantstamp protocol permission to withdraw in Step 1. As previously, you may find it handy to use the conversion function `web3.toWei(n, "ether")` (where `n` is the amount of QSP tokens) to obtain the correct QSP amount. Note that the price determines how quickly an audit request will be picked by some audit node. Note: the price must be equal or
+exceed the lower cap returned by `await quantstamp_audit.getMinAuditPriceLowerCap({from: auditor});`.
 * `requestId` is the Id of your request.
 
 ### Step 3: Check status of your audit and view your security report
@@ -168,7 +169,8 @@ Each audit node operator may choose their own minimum acceptable prices per audi
 `await quantstamp_audit.setAuditNodePrice(price, {from: auditor});`
 
 where
-* `price` is the minimum amount of QSP you want to charge per audit. Please note that this amount needs to be multiplied by 10^18 (similarly to how ETH gets converted into Wei). One way of doing the conversion is via `web3.toWei(n, "ether")`, where `n` is the amount of QSP tokens.
+* `price` is the minimum amount of QSP you want to charge per audit. Please note that this amount needs to be multiplied by 10^18 (similarly to how ETH gets converted into Wei). One way of doing the conversion is via `web3.toWei(n, "ether")`, where `n` is the amount of QSP tokens. Note: the price must be equal or
+exceed the lower cap returned by `await quantstamp_audit.getMinAuditPriceLowerCap({from: auditor});`.
 
 ### Step 4: Wait for any incoming audit requests.
 
@@ -390,6 +392,7 @@ This includes running Truffle tests and collecting coverage report for [Coverall
 1. `npm run command -- -n=dev -a=reset-min-price -p 0x123456789` resets the min price of the given node address to max-uint256
 1. `npm run command -- -n=dev -a=set-min-price-to-accept-any-request -p 0x123456789` sets the min price of the given node to 0 enabling the [cleanup process](https://quantstamp.atlassian.net/wiki/spaces/QUAN/pages/95354881/Monitoring+Resources#MonitoringResources-Cleaningupauditrequests)
 1. `npm run command -- -n=dev -a=set-max-assigned -p 100` sets "maximum assigned nodes"
+1. `npm run command -- -n=dev -a=set-min-audit-price-lower-cap -p 100000000000000000000` sets min audit price's lower cap to 1000 QSP
 1. `npm run command -- -n=dev -a=set-min-stake -p 2000000000000000000` sets minimum staking amount to 2 QSP
 1. `npm run command -- -n=dev -a=set-slash-percentage -p 20` sets the slash percentage to 20%
 1. `npm run command -- -n=dev -a=set-max-assigned -p 100` sets "maximum assigned requests"

--- a/contracts/QuantstampAudit.sol
+++ b/contracts/QuantstampAudit.sol
@@ -221,7 +221,7 @@ contract QuantstampAudit is Pausable {
    */
   function requestAuditWithPriceHint(string contractUri, uint256 price, uint256 existingPrice) public whenNotPaused returns(uint256) {
     require(price > 0);
-    meetsLowerCap(price);
+    require(price >= minAuditPriceLowerCap);
 
     // transfer tokens to the data contract
     require(auditData.token().transferFrom(msg.sender, address(auditData), price));
@@ -533,7 +533,7 @@ contract QuantstampAudit is Pausable {
     }
 
     uint256 minPrice = auditData.getMinAuditPrice(msg.sender);
-    meetsLowerCap(minPrice);
+    require(minPrice >= minAuditPriceLowerCap);
 
     // check that the audit node has staked enough QSP
     if (isRequestAvailable == AuditAvailabilityState.Understaked) {
@@ -573,7 +573,7 @@ contract QuantstampAudit is Pausable {
    * @param price The minimum price.
    */
   function setAuditNodePrice(uint256 price) public {
-    meetsLowerCap(price);
+    require(price >= minAuditPriceLowerCap);
     require(price <= auditData.token().totalSupply());
     auditData.setMinAuditPrice(msg.sender, price);
     emit LogAuditNodePriceChanged(msg.sender, price);
@@ -671,13 +671,6 @@ contract QuantstampAudit is Pausable {
    */
   function auditQueueExists() internal view returns(bool) {
     return priceList.listExists();
-  }
-
-  function meetsLowerCap(uint256 price) internal view returns (bool) {
-    uint lowerCap = getMinAuditPriceLowerCap();
-    if (lowerCap != 0) {
-      require(price >= lowerCap);
-    }
   }
 
   /**

--- a/contracts/QuantstampAuditView.sol
+++ b/contracts/QuantstampAuditView.sol
@@ -46,6 +46,13 @@ contract QuantstampAuditView is Ownable {
   function getReportHash(uint256 requestId) public view returns (bytes32) {
     return keccak256(reportData.getReport(requestId));
   }
+
+  /**
+   * @dev Returns the lower cap of the audit prices.
+   */
+  function getMinAuditPriceLowerCap() public view returns (uint256) {
+    return audit.getMinAuditPriceLowerCap();
+  }
   
   /**
    * @dev Returns the sum of min audit prices.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "audit-contract",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "description": "",
   "main": "truffle-config.js",
   "directories": {

--- a/test/quantstamp_audit_view.js
+++ b/test/quantstamp_audit_view.js
@@ -227,4 +227,9 @@ contract('QuantstampAuditView', function(accounts) {
     assert.notEqual(hashOfNonExistedReport, hashOfReport);
   });
 
+  it("should return the lower cap", async function () {
+    const price = 123;
+    await quantstamp_audit.setMinAuditPriceLowerCap(price, {from: owner});
+    assert.equal(price, await quantstamp_audit_view.getMinAuditPriceLowerCap());
+  });
 });


### PR DESCRIPTION
Scan prices set by nodes or specified by requestors are capped from the lower end.

## Description
1. Fail the `setMinAuditPrice(...)` call if the price is lower than the lower cap
2. Fail the `requestAudit(...)` call if the price is lower than the lower cap
3. Lower cap is exposed through the View contract
4. Tests added
5. If the cap is set to 0, it is not enforced

## Motivation and Context

This addresses concerns of node operators that certain nodes altruistically set the scan price too low or attempt to "outbid" the 

## How Has This Been Tested?

Automated tests

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.